### PR TITLE
Made `func getIdentityMatrix(dim:)` simpler and `O(n)` instead of `O(n^2)`

### DIFF
--- a/HCKalmanFilter/HCMatrixObject.swift
+++ b/HCKalmanFilter/HCMatrixObject.swift
@@ -46,13 +46,7 @@ class HCMatrixObject
         
         for i in 0..<dim
         {
-            for j in 0..<dim
-            {
-                if i == j
-                {
-                    identityMatrix.matrix[i,j] = 1.0
-                }
-            }
+            identityMatrix.matrix[i,i] = 1.0
         }
         
         return identityMatrix


### PR DESCRIPTION
The matrix is square and we're only assigning on the diagonal.
So there's really no point in visiting all the cells of the matrix.