### PR TITLE
Create Package.swift to use HCKalmanFilter with Swift Package Manager

### DIFF
--- a/HCKalmanFilter/HCMatrixObject.swift
+++ b/HCKalmanFilter/HCMatrixObject.swift
@@ -173,7 +173,7 @@ class HCMatrixObject
     {
         let result = HCMatrixObject(rows: left.rows, columns: left.columns)
         
-        result.matrix = Surge.add(left.matrix, y: right.matrix)
+        result.matrix = Surge.add(left.matrix, right.matrix)
         
         return result
     }
@@ -214,7 +214,7 @@ class HCMatrixObject
     /// - returns: result HCMatrixObject object of multiplication operation
     static func *(left:HCMatrixObject, right:HCMatrixObject) -> HCMatrixObject?
     {
-        let resultMatrix = Surge.mul(left.matrix, y: right.matrix)
+        let resultMatrix = Surge.mul(left.matrix, right.matrix)
         
         let result = HCMatrixObject(rows: resultMatrix.rows,columns: resultMatrix.columns)
         result.matrix = resultMatrix

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "HCKalmanFilter",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "HCKalmanFilter",
+            targets: ["HCKalmanFilter"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/Jounce/Surge.git", .upToNextMajor(from: "2.3.0")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "HCKalmanFilter",
+            dependencies: ["Surge"]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "HCKalmanFilter",
-            dependencies: ["Surge"]),
+            dependencies: ["Surge"],
+            path: "HCKalmanFilter"),
     ]
 )


### PR DESCRIPTION
Had to also change 2 surge parameter labels when using Xcode 11.6 and surge 2.3.0.